### PR TITLE
Add missing return on 530 auth-required

### DIFF
--- a/secure_smtpd/smtp_channel.py
+++ b/secure_smtpd/smtp_channel.py
@@ -124,6 +124,7 @@ class SMTPChannel(smtpd.SMTPChannel):
             if not command in ['AUTH', 'EHLO', 'HELO', 'NOOP', 'RSET', 'QUIT']:
                 if self.require_authentication and not self.authenticated:
                     self.push('530 Authentication required')
+                    return
                     
             method = getattr(self, 'smtp_' + command, None)
             if not method:


### PR DESCRIPTION
Without this, it sends 2 replies, and confuses the client if it tries to continue to talk to the server.
