### PR TITLE
fix crasher if waiting for accept

### DIFF
--- a/secure_smtpd/smtp_server.py
+++ b/secure_smtpd/smtp_server.py
@@ -34,6 +34,7 @@ class SMTPServer(smtpd.SMTPServer):
     def _accept_subprocess(self, queue):
         while True:
             try:
+                newsocket = None
                 self.socket.setblocking(1)
                 pair = self.accept()
                 map = {}
@@ -71,7 +72,8 @@ class SMTPServer(smtpd.SMTPServer):
                 self._shutdown_socket(newsocket)
                 self.logger.info('_accept_subprocess(): smtp channel terminated asyncore.')
             except Exception as e:
-                self._shutdown_socket(newsocket)
+                if newsocket is not None:
+                    self._shutdown_socket(newsocket)
                 self.logger.error('_accept_subprocess(): uncaught exception: %s' % str(e))
 
     def _shutdown_socket(self, s):


### PR DESCRIPTION
Fixes a boatload of errors. This would get spammed relentlessly to my logs:

```
Process Process-53:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/target/Forest/Workspace/wetpaint/venv/local/lib/python2.7/site-packages/secure_smtpd/smtp_server.py", line 74, in _accept_subprocess
    self._shutdown_socket(newsocket)
UnboundLocalError: local variable 'newsocket' referenced before assignment
```
